### PR TITLE
メッセージモデルの設定

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,3 @@
+class Message < ApplicationRecord
+
+end

--- a/db/migrate/20191127024905_create_messages.rb
+++ b/db/migrate/20191127024905_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration[5.0]
+  def change
+    create_table :messages do |t|
+      t.text :text
+      t.text :image
+      t.references :group, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
What
メッセージモデルのDB設定
user_idとgroup_idはカリキュラムに従い、referencesで設定
Why
主要項目のメッセージ機能設定のため