### PR TITLE
グループ機能修正

### DIFF
--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -189,23 +189,25 @@
         bottom: 0px;
  
         &__input_box {
-          width: calc(100vw - 300px - 210px);
+          height: 50px;
+          width: calc(100vw - 300px - 190px);
           background-color:#fff;
           color: #000;
           font-size: 16px;
-          padding-left: 10px;
-          padding-right: 10px;
           margin-right: 15px;
           border: solid 0px;
           display: flex;
           justify-content: space-between;
+          float: left;
 
             &__new_message {
               height: 50px;
-              width: calc(100% - 300px);
+              width: calc(100vw - 300px - 230px);
               background-color:#fff;
               color: #000;
               font-size: 16px;
+              padding-left: 10px;
+              padding-right: 10px;
               border: solid 0px;
               line-height: 50px;
             }

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -25,7 +25,7 @@ class GroupsController < ApplicationController
   def update
   # @group = Group.find(params[:id]) ///set_tweetでまとめる
     if @group.update(group_params)
-      redirect_to root_path, notice: 'グループを更新しました'
+      redirect_to group_messages_path(@group), notice: 'グループを更新しました'
     else
       render :edit
     end  

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -2,11 +2,15 @@
   .main_chat__main_header
     .main_chat__main_header__left_box
       .main_chat__main_header__left_box__current_group
-        aki
-      .main_chat__main_header__left_box__member_list    
-        Members:
+        = link_to group_messages_path(@group) do
+          = @group.name
+      .main_chat__main_header__left_box__member_list
+        Members: 
+        - @group.users.each do |user|   
+          = user.name
     .main_chat__main_header__edit_btn
-      Edit
+      = link_to "Edit", edit_group_path(@group), class: 'btn'
+      
   .main_chat__massages
     = render @messages
  


### PR DESCRIPTION
What
グループ投稿で仮置きとしていた箇所（グループ名、ユーザー名）をリンクさせる
グループ登録修正ボタンへのルートパス埋め込みを行う
グループ登録修正後のルートパスの修正を行う

Why
各種画面の遷移機能の実装のため
