### PR TITLE
リンク部分の下線修正

### DIFF
--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -53,25 +53,25 @@
       overflow: scroll;
     
         &__group_box {
-          padding-top: 20px;
+          text-decoration: none;
+          padding-top: 10px;
           padding-bottom: 40px;
 
             &__name_box {
-              height: 15px;
+              height: 20px;
               width: 260px;
               color: #fff;
               font-size: 15px;
-              line-height: 15px;
+              line-height: 20px;
               margin-right: 20px; 
-              margin-bottom: 10px;
+              margin-bottom: 5px;
             }
             &__message_box {
-              height: 11px;
+              height: 18px;
               width: 260px;
               color: #fff;
               font-size: 11px;
-              line-height: 11px;
-              margin-bottom: 40px;
+              line-height: 18px;
             } 
         }  
     }  
@@ -90,13 +90,6 @@
     width: 200px;
   }
 
-
-  .p {
-    color: #333333;
-    font-size: 20px;
-    font-weight: normal;
-    text-decoration: none;   
-  }
   &__btn{
     color: #38aef0;
     text-decoration: none;
@@ -117,6 +110,7 @@
         width: 200px;
         padding-top: 35px;
         padding-bottom: 14px;
+        text-decoration: none;   
 
         &__group_name { 
           height: 20px;    
@@ -127,12 +121,6 @@
           margin-bottom: 15px;
           pointer-events: none;
           text-decoration: none;
-          .p {
-            color: #333333;
-            font-size: 20px;
-            font-weight: normal;
-            text-decoration: none;   
-          }       
         }
 
         &__member_list {

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -2,8 +2,8 @@
   .main_chat__main_header
     .main_chat__main_header__left_box
       .main_chat__main_header__left_box__group_name
-        = link_to group_messages_path(@group) do
-          %p= @group.name
+        = link_to group_messages_path(@group) ,class:"main_chat__main_header__left_box__group_name" do
+          = @group.name
       .main_chat__main_header__left_box__member_list
         Members: 
         - @group.users.each do |user|   

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -10,8 +10,8 @@
           %i.fas.fa-cog
   .side_bar__groups
     - current_user.groups.each do |group|
-      .side_bar_groups__group_box
-        = link_to group_messages_path(group) do
+      .side_bar__groups__group_box
+        = link_to group_messages_path(group),class: "side_bar__groups__group_box" do
           .side_bar__groups__group_box__name_box
             = group.name
           .side_bar__groups__group_box__message_box


### PR DESCRIPTION
What
グループ名、グループ最新コメントの
下線表示を修正
Why
サイトの見栄えの調整のため