### PR TITLE
修正_message.js_1218

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -53,7 +53,7 @@ $(function(){
   });
 
   var reloadMessages = function () {
-    if (window.location.href.match(/\/checks\/\d+/messages/)){
+    if (window.location.href.match(/\/groups\/\d+\/messages/)){
       var last_message_id = $('.main_chat__contents__messages:last').data('message-id'); 
       $.ajax({ 
         url: "api/messages", 


### PR DESCRIPTION
what
message.jsの記述に誤りがあったため修正
（誤）if (window.location.href.match(/\/checks\/\d+/messages/)){
 （正） if (window.location.href.match(/\/groups\/\d+\/messages/)){
why
json形式での投稿機能バグ修正のため